### PR TITLE
fix(normalize): return 0 if NaN

### DIFF
--- a/src/standard.ts
+++ b/src/standard.ts
@@ -141,5 +141,5 @@ export const normalize = (inputRange: [number, number], outputRange: [number, nu
   const minOld = inputRange[0]
   const maxOld = inputRange[1]
 
-  return ((maxNew - minNew) / (maxOld - minOld)) * (value - maxOld) + maxNew
+  return ((maxNew - minNew) / (maxOld - minOld)) * (value - maxOld) + maxNew || 0
 }


### PR DESCRIPTION
In case maxOld - minOld = 0, the function returns NaN which crashes the app.